### PR TITLE
Fix sidebar layout in React pages

### DIFF
--- a/frontend/src/pages/Dimension.tsx
+++ b/frontend/src/pages/Dimension.tsx
@@ -10,5 +10,10 @@ export default function DimensionPage() {
     btn?.addEventListener('click', handler)
     return () => btn?.removeEventListener('click', handler)
   }, [navigate])
-  return <div dangerouslySetInnerHTML={{ __html: content }} />
+  return (
+    <div
+      className="bg-gray-100 flex h-screen overflow-hidden text-lg font-sans"
+      dangerouslySetInnerHTML={{ __html: content }}
+    />
+  )
 }

--- a/frontend/src/pages/Materials.tsx
+++ b/frontend/src/pages/Materials.tsx
@@ -10,5 +10,10 @@ export default function MaterialsPage() {
     btn?.addEventListener('click', handler)
     return () => btn?.removeEventListener('click', handler)
   }, [navigate])
-  return <div dangerouslySetInnerHTML={{ __html: content }} />
+  return (
+    <div
+      className="bg-gray-100 flex h-screen overflow-hidden text-lg font-sans"
+      dangerouslySetInnerHTML={{ __html: content }}
+    />
+  )
 }

--- a/frontend/src/pages/Process.tsx
+++ b/frontend/src/pages/Process.tsx
@@ -11,5 +11,10 @@ export default function ProcessPage() {
     nextBtn?.addEventListener('click', handler)
     return () => nextBtn?.removeEventListener('click', handler)
   }, [navigate])
-  return <div dangerouslySetInnerHTML={{ __html: content }} />
+  return (
+    <div
+      className="bg-gray-100 flex h-screen overflow-hidden text-lg font-sans"
+      dangerouslySetInnerHTML={{ __html: content }}
+    />
+  )
 }

--- a/frontend/src/pages/Report.tsx
+++ b/frontend/src/pages/Report.tsx
@@ -1,5 +1,10 @@
 import content from '../html/report_prot.html?raw'
 
 export default function ReportPage() {
-  return <div dangerouslySetInnerHTML={{ __html: content }} />
+  return (
+    <div
+      className="bg-gray-100 flex h-screen overflow-hidden text-lg font-sans"
+      dangerouslySetInnerHTML={{ __html: content }}
+    />
+  )
 }

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -19,5 +19,10 @@ export default function SearchPage() {
       btn?.removeEventListener('click', handler)
     }
   }, [navigate])
-  return <div dangerouslySetInnerHTML={{ __html: content }} />
+  return (
+    <div
+      className="bg-gray-100 flex h-screen overflow-hidden text-lg font-sans"
+      dangerouslySetInnerHTML={{ __html: content }}
+    />
+  )
 }

--- a/frontend/src/pages/Upload.tsx
+++ b/frontend/src/pages/Upload.tsx
@@ -11,5 +11,10 @@ export default function UploadPage() {
     target?.addEventListener('click', handler)
     return () => target?.removeEventListener('click', handler)
   }, [navigate])
-  return <div dangerouslySetInnerHTML={{ __html: content }} />
+  return (
+    <div
+      className="bg-gray-100 flex h-screen overflow-hidden text-lg font-sans"
+      dangerouslySetInnerHTML={{ __html: content }}
+    />
+  )
 }


### PR DESCRIPTION
## Summary
- ensure wrapper around HTML prototypes has `flex` layout
- sidebar now appears to the left of page content

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6861fdea1d2c8327a3cf73540c724586